### PR TITLE
Update maxHotBuckets type from int to string

### DIFF
--- a/client/models/index.go
+++ b/client/models/index.go
@@ -25,7 +25,7 @@ type IndexObject struct {
 	MaxBloomBackfillBucketAge     string `json:"maxBloomBackfillBucketAge,omitempty" url:"maxBloomBackfillBucketAge,omitempty"`
 	MaxConcurrentOptimizes        int    `json:"maxConcurrentOptimizes,omitempty" url:"maxConcurrentOptimizes,omitempty"`
 	MaxDataSize                   string `json:"maxDataSize,omitempty" url:"maxDataSize,omitempty"`
-	MaxHotBuckets                 int    `json:"maxHotBuckets,omitempty" url:"maxHotBuckets,omitempty"`
+	MaxHotBuckets                 string `json:"maxHotBuckets,omitempty" url:"maxHotBuckets,omitempty"`
 	MaxHotIdleSecs                int    `json:"maxHotIdleSecs,omitempty" url:"maxHotIdleSecs,omitempty"`
 	MaxHotSpanSecs                int    `json:"maxHotSpanSecs,omitempty" url:"maxHotSpanSecs,omitempty"`
 	MaxMemMB                      int    `json:"maxMemMB,omitempty" url:"maxMemMB,omitempty"`

--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -146,10 +146,10 @@ func index() *schema.Resource {
 				Note: The precise size of your warm buckets may vary from maxDataSize, due to post-processing and timing issues with the rolling policy.`,
 			},
 			"max_hot_buckets": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: `Maximum hot buckets that can exist per index. Defaults to 3.
+				Description: `Maximum hot buckets that can exist per index. Defaults to auto.
 				When maxHotBuckets is exceeded, Splunk software rolls the least recently used (LRU) hot bucket to warm. Both normal hot buckets and quarantined hot buckets count towards this total. This setting operates independently of maxHotIdleSecs, which can also cause hot buckets to roll.`,
 			},
 			"max_hot_idle_secs": {


### PR DESCRIPTION
Temporary solution to fix maxHotBuckets until this is fixed on the provider.
https://github.com/splunk/terraform-provider-splunk/issues/124